### PR TITLE
NoScriptPatch Compatibility Patch

### DIFF
--- a/rl_bettercrew/_metadata
+++ b/rl_bettercrew/_metadata
@@ -4,5 +4,5 @@
   "friendlyName" : "Better Crew",
   "includes" : ["QuickbarMini"],
   "name" : "rl_bettercrew",
-  "version" : "1.4.0"
+  "version" : "1.4.0a"
 }

--- a/rl_bettercrew/objects/ancientvault/terraforge/terraforge.object.patch
+++ b/rl_bettercrew/objects/ancientvault/terraforge/terraforge.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberengineer" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/ancientvault/weaponupgradeanvil/weaponupgradeanvil.object.patch
+++ b/rl_bettercrew/objects/ancientvault/weaponupgradeanvil/weaponupgradeanvil.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmember" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmember"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/apex/apexbloodbank/apexbloodbank.object.patch
+++ b/rl_bettercrew/objects/apex/apexbloodbank/apexbloodbank.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/apex/apexcoolserver/apexcoolserver.object.patch
+++ b/rl_bettercrew/objects/apex/apexcoolserver/apexcoolserver.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/apex/apexcoolshelf2/apexcoolshelf2.object.patch
+++ b/rl_bettercrew/objects/apex/apexcoolshelf2/apexcoolshelf2.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/apex/apextorturebed/apextorturebed.object.patch
+++ b/rl_bettercrew/objects/apex/apextorturebed/apextorturebed.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberoutlaw" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/apex/apexwardrobe/apexwardrobe.object.patch
+++ b/rl_bettercrew/objects/apex/apexwardrobe/apexwardrobe.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/avian/tribalcloset1/tribalcloset1.object.patch
+++ b/rl_bettercrew/objects/avian/tribalcloset1/tribalcloset1.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/avian/tribalserver/tribalserver.object.patch
+++ b/rl_bettercrew/objects/avian/tribalserver/tribalserver.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/foundry/foundrybellow/foundrybellow.object.patch
+++ b/rl_bettercrew/objects/biome/foundry/foundrybellow/foundrybellow.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/foundry/ladlelarge/ladlelarge.object.patch
+++ b/rl_bettercrew/objects/biome/foundry/ladlelarge/ladlelarge.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/foundry/ladlesmall/ladlesmall.object.patch
+++ b/rl_bettercrew/objects/biome/foundry/ladlesmall/ladlesmall.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/foundry/lavatankcascade/lavatankcascade.object.patch
+++ b/rl_bettercrew/objects/biome/foundry/lavatankcascade/lavatankcascade.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/foundry/lavatanklarge/lavatanklarge.object.patch
+++ b/rl_bettercrew/objects/biome/foundry/lavatanklarge/lavatanklarge.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/foundry/lavatanksmall/lavatanksmall.object.patch
+++ b/rl_bettercrew/objects/biome/foundry/lavatanksmall/lavatanksmall.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/mushroom/shroomwardrobe/shroomwardrobe.object.patch
+++ b/rl_bettercrew/objects/biome/mushroom/shroomwardrobe/shroomwardrobe.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/scorchedcity/bombsheltershelf1/bombsheltershelf1.object.patch
+++ b/rl_bettercrew/objects/biome/scorchedcity/bombsheltershelf1/bombsheltershelf1.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermedic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/scorchedcity/dumpster/dumpster.object.patch
+++ b/rl_bettercrew/objects/biome/scorchedcity/dumpster/dumpster.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberjanitor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberjanitor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/scorchedcity/scorchedcitybrokenelectricbox1/scorchedcitybrokenelectricbox1.object.patch
+++ b/rl_bettercrew/objects/biome/scorchedcity/scorchedcitybrokenelectricbox1/scorchedcitybrokenelectricbox1.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/scorchedcity/scorchedcitybrokenelectricbox2/scorchedcitybrokenelectricbox2.object.patch
+++ b/rl_bettercrew/objects/biome/scorchedcity/scorchedcitybrokenelectricbox2/scorchedcitybrokenelectricbox2.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/scorchedcity/scorchedcitybrokentank/scorchedcitybrokentank.object.patch
+++ b/rl_bettercrew/objects/biome/scorchedcity/scorchedcitybrokentank/scorchedcitybrokentank.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/scorchedcity/scorchedcitychestdrawerlarge/scorchedcitychestdrawerlarge.object.patch
+++ b/rl_bettercrew/objects/biome/scorchedcity/scorchedcitychestdrawerlarge/scorchedcitychestdrawerlarge.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/steamspring/steamboiler1/steamboiler1.object.patch
+++ b/rl_bettercrew/objects/biome/steamspring/steamboiler1/steamboiler1.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/steamspring/steamboiler2/steamboiler2.object.patch
+++ b/rl_bettercrew/objects/biome/steamspring/steamboiler2/steamboiler2.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/biome/steamspring/steamboiler3/steamboiler3.object.patch
+++ b/rl_bettercrew/objects/biome/steamspring/steamboiler3/steamboiler3.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/crafting/capturestation/capturestation.object.patch
+++ b/rl_bettercrew/objects/crafting/capturestation/capturestation.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermedic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/crafting/fossilstation/fossilstation.object.patch
+++ b/rl_bettercrew/objects/crafting/fossilstation/fossilstation.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/crafting/mechcraftingtable/mechcraftingtable.object.patch
+++ b/rl_bettercrew/objects/crafting/mechcraftingtable/mechcraftingtable.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/crafting/pixelcompressor/pixelcompressor.object.patch
+++ b/rl_bettercrew/objects/crafting/pixelcompressor/pixelcompressor.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberoutlaw",
-      "crewmemberpenguinmerc"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw",
+        "crewmemberpenguinmerc"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/crafting/railcraftingtable/railcraftingtable.object.patch
+++ b/rl_bettercrew/objects/crafting/railcraftingtable/railcraftingtable.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/crafting/refinery/refinery.object.patch
+++ b/rl_bettercrew/objects/crafting/refinery/refinery.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/crafting/wiringstation/wiringstation.object.patch
+++ b/rl_bettercrew/objects/crafting/wiringstation/wiringstation.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/floran/florangiantpod/giantfloranpod.object.patch
+++ b/rl_bettercrew/objects/floran/florangiantpod/giantfloranpod.object.patch
@@ -1,16 +1,32 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow",
-      "crewmembermedic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow",
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/floran/floranpod1/floranpod1.object.patch
+++ b/rl_bettercrew/objects/floran/floranpod1/floranpod1.object.patch
@@ -1,16 +1,32 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow",
-      "crewmembermedic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow",
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/floran/floranpod2/floranpod2.object.patch
+++ b/rl_bettercrew/objects/floran/floranpod2/floranpod2.object.patch
@@ -1,16 +1,32 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow",
-      "crewmembermedic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow",
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/floran/floranpod3/floranpod3.object.patch
+++ b/rl_bettercrew/objects/floran/floranpod3/floranpod3.object.patch
@@ -1,16 +1,32 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow",
-      "crewmembermedic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow",
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/floran/plantrack/plantrack.object.patch
+++ b/rl_bettercrew/objects/floran/plantrack/plantrack.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberoutlaw" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/generic/datastation/datastation.object.patch
+++ b/rl_bettercrew/objects/generic/datastation/datastation.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/generic/mechassemblystation/mechassemblystation.object.patch
+++ b/rl_bettercrew/objects/generic/mechassemblystation/mechassemblystation.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberengineer" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/generic/recreationalvehicle/recreationalvehicle.object.patch
+++ b/rl_bettercrew/objects/generic/recreationalvehicle/recreationalvehicle.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/generic/shootingtarget/shootingtarget.object.patch
+++ b/rl_bettercrew/objects/generic/shootingtarget/shootingtarget.object.patch
@@ -1,14 +1,30 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmember",
-      "crewmemberoutlaw",
-      "crewmemberpenguinmerc"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmember",
+        "crewmemberoutlaw",
+        "crewmemberpenguinmerc"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/generic/weaponchest/weaponchest.object.patch
+++ b/rl_bettercrew/objects/generic/weaponchest/weaponchest.object.patch
@@ -1,14 +1,30 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmember",
-      "crewmemberoutlaw",
-      "crewmemberpenguinmerc"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmember",
+        "crewmemberoutlaw",
+        "crewmemberpenguinmerc"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/glitch/anvil/anvil.object.patch
+++ b/rl_bettercrew/objects/glitch/anvil/anvil.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmember" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmember"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/glitch/medievaldresser/medievaldresser.object.patch
+++ b/rl_bettercrew/objects/glitch/medievaldresser/medievaldresser.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/glitch/medievalfurnace/medievalfurnace.object.patch
+++ b/rl_bettercrew/objects/glitch/medievalfurnace/medievalfurnace.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/glitch/sewertank/sewertank.object.patch
+++ b/rl_bettercrew/objects/glitch/sewertank/sewertank.object.patch
@@ -1,16 +1,32 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/glitch/trashbag/trashbag.object.patch
+++ b/rl_bettercrew/objects/glitch/trashbag/trashbag.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberjanitor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberjanitor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/hoard/barrelgoldfilled/barrelgoldfilled.object.patch
+++ b/rl_bettercrew/objects/hoard/barrelgoldfilled/barrelgoldfilled.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberoutlaw",
-      "crewmemberpenguinmerc"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw",
+        "crewmemberpenguinmerc"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/hoard/woodencrategoldfilled/woodencrategoldfilled.object.patch
+++ b/rl_bettercrew/objects/hoard/woodencrategoldfilled/woodencrategoldfilled.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberoutlaw",
-      "crewmemberpenguinmerc"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw",
+        "crewmemberpenguinmerc"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/human/bunkerwires/bunkerwires.object.patch
+++ b/rl_bettercrew/objects/human/bunkerwires/bunkerwires.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/human/prisoncabinet1/prisoncabinet1.object.patch
+++ b/rl_bettercrew/objects/human/prisoncabinet1/prisoncabinet1.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermedic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/human/prisontorturebed1/prisontorturebed1.object.patch
+++ b/rl_bettercrew/objects/human/prisontorturebed1/prisontorturebed1.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberoutlaw" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/human/prisontorturebed2/prisontorturebed2.object.patch
+++ b/rl_bettercrew/objects/human/prisontorturebed2/prisontorturebed2.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberoutlaw" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/hylotl/hylotlclassicwardrobe1/hylotlclassicwardrobe1.object.patch
+++ b/rl_bettercrew/objects/hylotl/hylotlclassicwardrobe1/hylotlclassicwardrobe1.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/hylotl/hylotlfashionhologram/hylotlfashionhologram.object.patch
+++ b/rl_bettercrew/objects/hylotl/hylotlfashionhologram/hylotlfashionhologram.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/novakid/frontierfurnace/frontierfurnace.object.patch
+++ b/rl_bettercrew/objects/novakid/frontierfurnace/frontierfurnace.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/novakid/frontiervault/frontiervault.object.patch
+++ b/rl_bettercrew/objects/novakid/frontiervault/frontiervault.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberoutlaw",
-      "crewmemberpenguinmerc"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw",
+        "crewmemberpenguinmerc"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/novakid/safe/safe.object.patch
+++ b/rl_bettercrew/objects/novakid/safe/safe.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberoutlaw",
-      "crewmemberpenguinmerc"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberoutlaw",
+        "crewmemberpenguinmerc"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/novakid/saloonspittoon/saloonspittoon.object.patch
+++ b/rl_bettercrew/objects/novakid/saloonspittoon/saloonspittoon.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmemberjanitor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberjanitor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/office/officeserver/officeserver.object.patch
+++ b/rl_bettercrew/objects/office/officeserver/officeserver.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/outpost/outpostgenerator/outpostgenerator.object.patch
+++ b/rl_bettercrew/objects/outpost/outpostgenerator/outpostgenerator.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/outpost/outposttank/outposttank.object.patch
+++ b/rl_bettercrew/objects/outpost/outposttank/outposttank.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/space/astroserver/astroserver.object.patch
+++ b/rl_bettercrew/objects/space/astroserver/astroserver.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/space/stationmedscanner/stationmedscanner.object.patch
+++ b/rl_bettercrew/objects/space/stationmedscanner/stationmedscanner.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermedic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/space/stationpylon/stationpylon.object.patch
+++ b/rl_bettercrew/objects/space/stationpylon/stationpylon.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/space/telescope/telescope.object.patch
+++ b/rl_bettercrew/objects/space/telescope/telescope.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/themed/pastel/pastelwardrobe/pastelwardrobe.object.patch
+++ b/rl_bettercrew/objects/themed/pastel/pastelwardrobe/pastelwardrobe.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/themed/retroscifi/retroscifidresser/retroscifidresser.object.patch
+++ b/rl_bettercrew/objects/themed/retroscifi/retroscifidresser/retroscifidresser.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembertailor" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembertailor"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/themed/steampunk/steampunkdesk/steampunkdesk.object.patch
+++ b/rl_bettercrew/objects/themed/steampunk/steampunkdesk/steampunkdesk.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/upgrade/techconsole/techconsole.object.patch
+++ b/rl_bettercrew/objects/upgrade/techconsole/techconsole.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermedic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermedic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/wreck/wreckboiler/wreckboiler.object.patch
+++ b/rl_bettercrew/objects/wreck/wreckboiler/wreckboiler.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/wreck/wreckconsole2/wreckconsole2.object.patch
+++ b/rl_bettercrew/objects/wreck/wreckconsole2/wreckconsole2.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/wreck/wreckconsole3/wreckconsole3.object.patch
+++ b/rl_bettercrew/objects/wreck/wreckconsole3/wreckconsole3.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/wreck/wreckgenerator/wreckgenerator.object.patch
+++ b/rl_bettercrew/objects/wreck/wreckgenerator/wreckgenerator.object.patch
@@ -1,13 +1,29 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberengineer",
-      "crewmembermechanic"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberengineer",
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/wreck/wreckturbine2/wreckturbine2.object.patch
+++ b/rl_bettercrew/objects/wreck/wreckturbine2/wreckturbine2.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/wreck/wreckturbines/wreckturbines.object.patch
+++ b/rl_bettercrew/objects/wreck/wreckturbines/wreckturbines.object.patch
@@ -1,10 +1,28 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [ "crewmembermechanic" ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmembermechanic"
+      ]
+    }
+  ]
 ]

--- a/rl_bettercrew/objects/wreck/wreckvat1/wreckvat1.object.patch
+++ b/rl_bettercrew/objects/wreck/wreckvat1/wreckvat1.object.patch
@@ -1,15 +1,31 @@
 [
-  { "op" : "add",
-    "path" : "/scripts",
-    "value" : [ "/scripts/rl_crewanchorobject.lua" ]
-  },
-  { "op" : "add",
-    "path" : "/crewAnchorTags",
-    "value" : [
-      "crewmemberchemistblue",
-      "crewmemberchemistgreen",
-      "crewmemberchemistorange",
-      "crewmemberchemistyellow"
-    ]
-  }
+  [
+    {
+      "op" : "test",
+      "path" : "/scripts",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/scripts",
+      "value" : [ ]
+    }
+  ],
+  [
+    {
+      "op" : "add",
+      "path" : "/scripts/-",
+      "value" : "/scripts/rl_crewanchorobject.lua"
+    },
+    { 
+      "op" : "add",
+      "path" : "/crewAnchorTags",
+      "value" : [
+        "crewmemberchemistblue",
+        "crewmemberchemistgreen",
+        "crewmemberchemistorange",
+        "crewmemberchemistyellow"
+      ]
+    }
+  ]
 ]


### PR DESCRIPTION
The method of patching objects that don't have scripts in the vanilla game will actually over-write any script an other mod might have already added to it, causing several mods to not function properly.

To fix that, the .patch files for these items now use 2 batches.

1. The first batch checks if the path exists or not, and if not, creates the /scripts path. If the path already exist because an other mod added a script to it, that first batch will do nothing.
2. The second batch adds to this now-for-sure existing path the rl_crewanchorobject.lua script, either as the only script, or after an already patched-in script by an other mod.